### PR TITLE
Update Chapel solution using compile time constants...

### DIFF
--- a/PrimeChapel/solution_1/README.md
+++ b/PrimeChapel/solution_1/README.md
@@ -29,11 +29,11 @@ The Dockerfile uses an official Debian image and then builds and installs Chapel
 
 ## Output
 ```
-GordonBGood_bittwiddle;7776;5.00044;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unpeeled;9838;5.00047;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unpeeled_block;10319;5.00005;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unrolled;15865;5.0002;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unrolled_hybrid;28818;5.00012;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_bittwiddle;7728;5.00028;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_stride8;9828;5.00024;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_stride8_block16K;10326;5.00016;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_extreme;15810;5.00001;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_extreme_hybrid;34785;5.00003;1;algorithm=base,faithful=yes,bits=1
 ```
 
 ## Benchmarks
@@ -41,25 +41,25 @@ GordonBGood_unrolled_hybrid;28818;5.00012;1;algorithm=base,faithful=yes,bits=1
 Running locally on my Intel SkyLake i5-6500 at 3.6 GHz when single threaded, I get some astounding numbers:
 
 ```
-GordonBGood_bittwiddle;7803;5.00046;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unpeeled;9768;5.00028;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unpeeled_block;10356;5.00035;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unrolled;16259;5.00009;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unrolled_hybrid;28948;5.00005;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_bittwiddle;7728;5.00028;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_stride8;9828;5.00024;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_stride8_block16K;10326;5.00016;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_extreme;15810;5.00001;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_extreme_hybrid;34785;5.00003;1;algorithm=base,faithful=yes,bits=1
 ```
 Which matches the results when run with Docker on the same machine as follows:
 
 ```
-                                                                Single-threaded                                                                
-┌───────┬────────────────┬──────────┬─────────────────────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
-│ Index │ Implementation │ Solution │ Label                       │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
-├───────┼────────────────┼──────────┼─────────────────────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
-│   1   │ chapel         │ 1        │ GordonBGood_unrolled_hybrid │ 29556  │ 5.00014  │    1    │   base    │   yes    │ 1    │  5911.03449   │
-│   2   │ chapel         │ 1        │ GordonBGood_unrolled        │ 16499  │ 5.00002  │    1    │   base    │   yes    │ 1    │  3299.78680   │
-│   3   │ chapel         │ 1        │ GordonBGood_unpeeled_block  │ 10499  │ 5.00003  │    1    │   base    │   yes    │ 1    │  2099.78740   │
-│   4   │ chapel         │ 1        │ GordonBGood_unpeeled        │  9969  │ 5.00005  │    1    │   base    │   yes    │ 1    │  1993.78006   │
-│   5   │ chapel         │ 1        │ GordonBGood_bittwiddle      │  7851  │ 5.00032  │    1    │   base    │   yes    │ 1    │  1570.09951   │
-└───────┴────────────────┴──────────┴─────────────────────────────┴────────┴──────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
+                                                                Single-threaded                                                                 
+┌───────┬────────────────┬──────────┬──────────────────────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
+│ Index │ Implementation │ Solution │ Label                        │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
+├───────┼────────────────┼──────────┼──────────────────────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
+│   1   │ chapel         │ 1        │ GordonBGood_extreme_hybrid   │ 34555  │ 5.00013  │    1    │   base    │   yes    │ 1    │  6910.82032   │
+│   2   │ chapel         │ 1        │ GordonBGood_extreme          │ 16206  │ 5.00016  │    1    │   base    │   yes    │ 1    │  3241.09628   │
+│   3   │ chapel         │ 1        │ GordonBGood_stride8_block16K │ 10262  │ 5.00046  │    1    │   base    │   yes    │ 1    │  2052.21120   │
+│   4   │ chapel         │ 1        │ GordonBGood_stride8          │  9565  │ 5.00020  │    1    │   base    │   yes    │ 1    │  1912.92348   │
+│   5   │ chapel         │ 1        │ GordonBGood_bittwiddle       │  7743  │ 5.00032  │    1    │   base    │   yes    │ 1    │  1548.50090   │
+└───────┴────────────────┴──────────┴──────────────────────────────┴────────┴──────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
 ```
 
 ## Notes
@@ -70,8 +70,8 @@ The techniques used are as follows:
 2. Loop "unpeeling" where the culling marking loops are simplified by recognizing that modulo math means every eighth culling/marking position is at the same bit index per byte with the byte indexes separated by the base prime value span so that are eight loops culling/marking with each using a different fixed byte mask.  This is faster because the simple non-"bit-twiddling" masking operations can be very simple, but meaning that there is more loop overhead (eight loops per base prime value instead of one) and there is still "cache thrashing" as each loop culls/marks across the entire sieve buffer which spans several CPU caches in the case of common CPU's.
 3. Loop "unpeeling" by cache sized blocks, which reduces the "cache thrashing" by running the above eight loops across each block in turn, saving the next marking/culling index in an array for use on the next block.  As full page segmentation isn't allowed (determining all base prime values as a separate process), this reduces but can't eliminate "cache thrashing".
 4. Extreme loop unrolling, which combines the eight loops above into a single loop running across the entire sieve buffer; since the eight loops are combined and as page segmentation is not allowed, there is no advantage (and an increased overhead) to culling by cache-sized blocks.  Since Chapel does not have computed goto's, this feature is emulated manually by creating an array containing "functions" that cull by each of the possible 64 culling patterns, which patterns depend on the modulo eight of the span (the base prime value) and the modulo eight of the starting bit index (eight times eight is 64 elements), of which not all are used for this program.  Since only odd base prime values are used, there are only four base prime modulo eight entries for span value, and since we are starting all of them at the index of the base prime squared, then each base prime modulo creates a constant start bit index modulo eight; thus, there are only four out of the 64 entries used for this program, but the rest are kept for completeness in other applications.
-5. A hybrid approach where extreme loop unrolling as per the above is used for larger base prime values above a threshold and a dense algorithm for those base prime values below.  For this implementation the threshold is chosen so dense base primes are considered to be nineteen and below; larger values up to about 31 would likely make the code even slightly faster, but as Chapel does not have macros, a code generator must be used for the cases handling each odd value up to the threshold and the source could becomes rather long for only a small extra benefit.  Instead of addressing the sieve buffer array by byte indices as for extreme loop unrolling, the dense processing addresses the buffer by 64-bit words so that the maximum number of small-span composites are contained in each word.  There have been solutions that correctly haven't been accepted as `faithful to base` because in addressing by words they cleared all the dense composites in the word with a single instruction using a mask, but this implementation clears them bit by bit with individual operations in a manner similar to the technique used in the Rust "striped hybrid reset" technique but using larger words instead of bytes; thus this version should be accepted as `faithful to base`.  As well, as it is expected that we don't use any knowledge of base primes other than the only even prime of two, the implementation covers all of the odd value possibilities and thus includes the values of nine and fifteen even thought these are not prime and the code will never be used.
+5. A hybrid approach where extreme loop unrolling as per the above is used for larger base prime values above a threshold and a dense algorithm for those base prime values below.  For this implementation the threshold is chosen so dense base primes are considered to be 63 and below; larger values up to about 129 would likely make the code even slightly faster, but the compile time would greatly increase for the instantiation of double the number of classes with double the number of compile time determined operations per class for only a small extra benefit.  Instead of addressing the sieve buffer array by byte indices as for extreme loop unrolling, the dense processing addresses the buffer by 64-bit words so that the maximum number of small-span composites are contained in each word.  There have been solutions that correctly haven't been accepted as `faithful to base` because in addressing by words they cleared all the dense composites in the word with a single instruction using a mask, but this implementation clears them bit by bit with individual operations in a manner similar to the technique used in the Rust "striped hybrid reset" technique; thus this version should be accepted as `faithful to base`.  As well, as it is expected that we don't use any knowledge of base primes other than the only even prime is two, the implementation covers all of the odd value possibilities and thus includes the values of nine, fifteen, etc., even thought these are not prime and the code will never be used.
 
 In implementing "Extreme Loop Unrolling", since Chapel does not have general-use first class functions (the current implementation can only access global and local (inside the scope of the function) variables, these are emulated using a class hierarchy, which classes can emulate closures by using the class fields to capture variables from the environment (not used here) and the default `this` method as the "apply" method of a Functor class.  Chapel's parameterized generic classes act as class/Functor templates for this application.  This class "template" is then instantiated once for each of the 64 "goto" table entries.  The use of this table is then structured to look like a call to a "setbit(array, start, limit, step)" function to make it clear that there is one operation per composite number culling/marking.
 
-For the dense hybrid technique add-on, the same general form using an array of classes-representing-functions is used, but these can't be generated automatically from a single parameterized generic class/template as the code varies per step value and thus code generation had to be used.  In another language that had true macros and not just templates, the code could all be generated in just a few lines of code, possibly inline to the source.  For languages with this facility, the threshold of dense base prime values could be extended to include 31 for an extra at least perceptible speed increase.
+For the dense hybrid technique add-on, the same general form using an array of classes-representing-functions is used.  In another language that had true macros and not just templates, the code could all be generated in just a few lines of code, possibly inline to the source.  For languages with this facility, the threshold of dense base prime values could be extended to include much higher values for an extra at least perceptible speed increase.

--- a/PrimeChapel/solution_1/primes.chpl
+++ b/PrimeChapel/solution_1/primes.chpl
@@ -16,6 +16,8 @@ enum Techniques { BitTwiddle, Unpeeled, UnpeeledBlock, Unrolled, UnrolledHybrid 
 
 const CPUL1CACHE: int = 16384; // in bytes
 
+const HYBRID_THRESHOLD: int = 63; // dense base prime threshold
+
 const RESULTS =
   [ 10: Prime => 4,
     100: Prime => 25,
@@ -110,8 +112,77 @@ const unrollr = [ // note that only cases 15, 27, 43, and 63 are used!
 // each different generic param instantiation makes a different sub class...
 // don't have macros, so must generate code by hand or with generator...
 
-class URh3: UR {
-  // hybrid bit setting by densely packed uint64's...
+class URx: UR {
+  param ndx: uint(8);
+  param bp = (ndx: int(64) + ndx: int(64)) + 3;
+  param strt = (bp * bp - 3) >> 1;
+  param strtlmt = (strt + 64) & -64;
+  param r = (strtlmt - strt) % bp;
+  param s0 = if r == 0 then 0 else (bp - r) & 63;
+  param m0 = 1: uint(64) << s0;
+  param s1 = s0 + bp; param i1 = s1 >> 6; param m1 = 1: uint(64) << (s1 & 63);
+  param s2 = s1 + bp; param i2 = s2 >> 6; param m2 = 1: uint(64) << (s2 & 63);
+  param s3 = s2 + bp; param i3 = s3 >> 6; param m3 = 1: uint(64) << (s3 & 63);
+  param s4 = s3 + bp; param i4 = s4 >> 6; param m4 = 1: uint(64) << (s4 & 63);
+  param s5 = s4 + bp; param i5 = s5 >> 6; param m5 = 1: uint(64) << (s5 & 63);
+  param s6 = s5 + bp; param i6 = s6 >> 6; param m6 = 1: uint(64) << (s6 & 63);
+  param s7 = s6 + bp; param i7 = s7 >> 6; param m7 = 1: uint(64) << (s7 & 63);
+  param s8 = s7 + bp; param i8 = s8 >> 6; param m8 = 1: uint(64) << (s8 & 63);
+  param s9 = s8 + bp; param i9 = s9 >> 6; param m9 = 1: uint(64) << (s9 & 63);
+  param s10 = s9 + bp; param i10 = s10 >> 6; param m10 = 1: uint(64) << (s10 & 63);
+  param s11 = s10 + bp; param i11 = s11 >> 6; param m11 = 1: uint(64) << (s11 & 63);
+  param s12 = s11 + bp; param i12 = s12 >> 6; param m12 = 1: uint(64) << (s12 & 63);
+  param s13 = s12 + bp; param i13 = s13 >> 6; param m13 = 1: uint(64) << (s13 & 63);
+  param s14 = s13 + bp; param i14 = s14 >> 6; param m14 = 1: uint(64) << (s14 & 63);
+  param s15 = s14 + bp; param i15 = s15 >> 6; param m15 = 1: uint(64) << (s15 & 63);
+  param s16 = s15 + bp; param i16 = s16 >> 6; param m16 = 1: uint(64) << (s16 & 63);
+  param s17 = s16 + bp; param i17 = s17 >> 6; param m17 = 1: uint(64) << (s17 & 63);
+  param s18 = s17 + bp; param i18 = s18 >> 6; param m18 = 1: uint(64) << (s18 & 63);
+  param s19 = s18 + bp; param i19 = s19 >> 6; param m19 = 1: uint(64) << (s19 & 63);
+  param s20 = s19 + bp; param i20 = s20 >> 6; param m20 = 1: uint(64) << (s20 & 63);
+  param s21 = s20 + bp; param i21 = s21 >> 6; param m21 = 1: uint(64) << (s21 & 63);
+  param s22 = s21 + bp; param i22 = s22 >> 6; param m22 = 1: uint(64) << (s22 & 63);
+  param s23 = s22 + bp; param i23 = s23 >> 6; param m23 = 1: uint(64) << (s23 & 63);
+  param s24 = s23 + bp; param i24 = s24 >> 6; param m24 = 1: uint(64) << (s24 & 63);
+  param s25 = s24 + bp; param i25 = s25 >> 6; param m25 = 1: uint(64) << (s25 & 63);
+  param s26 = s25 + bp; param i26 = s26 >> 6; param m26 = 1: uint(64) << (s26 & 63);
+  param s27 = s26 + bp; param i27 = s27 >> 6; param m27 = 1: uint(64) << (s27 & 63);
+  param s28 = s27 + bp; param i28 = s28 >> 6; param m28 = 1: uint(64) << (s28 & 63);
+  param s29 = s28 + bp; param i29 = s29 >> 6; param m29 = 1: uint(64) << (s29 & 63);
+  param s30 = s29 + bp; param i30 = s30 >> 6; param m30 = 1: uint(64) << (s30 & 63);
+  param s31 = s30 + bp; param i31 = s31 >> 6; param m31 = 1: uint(64) << (s31 & 63);
+  param s32 = s31 + bp; param i32 = s32 >> 6; param m32 = 1: uint(64) << (s32 & 63);
+  param s33 = s32 + bp; param i33 = s33 >> 6; param m33 = 1: uint(64) << (s33 & 63);
+  param s34 = s33 + bp; param i34 = s34 >> 6; param m34 = 1: uint(64) << (s34 & 63);
+  param s35 = s34 + bp; param i35 = s35 >> 6; param m35 = 1: uint(64) << (s35 & 63);
+  param s36 = s35 + bp; param i36 = s36 >> 6; param m36 = 1: uint(64) << (s36 & 63);
+  param s37 = s36 + bp; param i37 = s37 >> 6; param m37 = 1: uint(64) << (s37 & 63);
+  param s38 = s37 + bp; param i38 = s38 >> 6; param m38 = 1: uint(64) << (s38 & 63);
+  param s39 = s38 + bp; param i39 = s39 >> 6; param m39 = 1: uint(64) << (s39 & 63);
+  param s40 = s39 + bp; param i40 = s40 >> 6; param m40 = 1: uint(64) << (s40 & 63);
+  param s41 = s40 + bp; param i41 = s41 >> 6; param m41 = 1: uint(64) << (s41 & 63);
+  param s42 = s41 + bp; param i42 = s42 >> 6; param m42 = 1: uint(64) << (s42 & 63);
+  param s43 = s42 + bp; param i43 = s43 >> 6; param m43 = 1: uint(64) << (s43 & 63);
+  param s44 = s43 + bp; param i44 = s44 >> 6; param m44 = 1: uint(64) << (s44 & 63);
+  param s45 = s44 + bp; param i45 = s45 >> 6; param m45 = 1: uint(64) << (s45 & 63);
+  param s46 = s45 + bp; param i46 = s46 >> 6; param m46 = 1: uint(64) << (s46 & 63);
+  param s47 = s46 + bp; param i47 = s47 >> 6; param m47 = 1: uint(64) << (s47 & 63);
+  param s48 = s47 + bp; param i48 = s48 >> 6; param m48 = 1: uint(64) << (s48 & 63);
+  param s49 = s48 + bp; param i49 = s49 >> 6; param m49 = 1: uint(64) << (s49 & 63);
+  param s50 = s49 + bp; param i50 = s50 >> 6; param m50 = 1: uint(64) << (s50 & 63);
+  param s51 = s50 + bp; param i51 = s51 >> 6; param m51 = 1: uint(64) << (s51 & 63);
+  param s52 = s51 + bp; param i52 = s52 >> 6; param m52 = 1: uint(64) << (s52 & 63);
+  param s53 = s52 + bp; param i53 = s53 >> 6; param m53 = 1: uint(64) << (s53 & 63);
+  param s54 = s53 + bp; param i54 = s54 >> 6; param m54 = 1: uint(64) << (s54 & 63);
+  param s55 = s54 + bp; param i55 = s55 >> 6; param m55 = 1: uint(64) << (s55 & 63);
+  param s56 = s55 + bp; param i56 = s56 >> 6; param m56 = 1: uint(64) << (s56 & 63);
+  param s57 = s56 + bp; param i57 = s57 >> 6; param m57 = 1: uint(64) << (s57 & 63);
+  param s58 = s57 + bp; param i58 = s58 >> 6; param m58 = 1: uint(64) << (s58 & 63);
+  param s59 = s58 + bp; param i59 = s59 >> 6; param m59 = 1: uint(64) << (s59 & 63);
+  param s60 = s59 + bp; param i60 = s60 >> 6; param m60 = 1: uint(64) << (s60 & 63);
+  param s61 = s60 + bp; param i61 = s61 >> 6; param m61 = 1: uint(64) << (s61 & 63);
+  param s62 = s61 + bp; param i62 = s62 >> 6; param m62 = 1: uint(64) << (s62 & 63);
+  param s63 = s62 + bp; param i63 = s63 >> 6; param m63 = 1: uint(64) << (s63 & 63);
   override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
     const ilmt = si | 63; // make stop limit to next 64-bit boundary
     var biti = si;
@@ -120,726 +191,70 @@ class URh3: UR {
       c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
     var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
     while rp: int(64) <= rlmtp: int(64) {
-      var v = rp(0) | 0x0000000000000004: uint(64);
-      v = v | 0x0000000000000020: uint(64);
-      v = v | 0x0000000000000100: uint(64);
-      v = v | 0x0000000000000800: uint(64);
-      v = v | 0x0000000000004000: uint(64);
-      v = v | 0x0000000000020000: uint(64);
-      v = v | 0x0000000000100000: uint(64);
-      v = v | 0x0000000000800000: uint(64);
-      v = v | 0x0000000004000000: uint(64);
-      v = v | 0x0000000020000000: uint(64);
-      v = v | 0x0000000100000000: uint(64);
-      v = v | 0x0000000800000000: uint(64);
-      v = v | 0x0000004000000000: uint(64);
-      v = v | 0x0000020000000000: uint(64);
-      v = v | 0x0000100000000000: uint(64);
-      v = v | 0x0000800000000000: uint(64);
-      v = v | 0x0004000000000000: uint(64);
-      v = v | 0x0020000000000000: uint(64);
-      v = v | 0x0100000000000000: uint(64);
-      v = v | 0x0800000000000000: uint(64);
-      rp(0) = v | 0x4000000000000000: uint(64);
-      v = rp(1) | 0x0000000000000002: uint(64);
-      v = v | 0x0000000000000010: uint(64);
-      v = v | 0x0000000000000080: uint(64);
-      v = v | 0x0000000000000400: uint(64);
-      v = v | 0x0000000000002000: uint(64);
-      v = v | 0x0000000000010000: uint(64);
-      v = v | 0x0000000000080000: uint(64);
-      v = v | 0x0000000000400000: uint(64);
-      v = v | 0x0000000002000000: uint(64);
-      v = v | 0x0000000010000000: uint(64);
-      v = v | 0x0000000080000000: uint(64);
-      v = v | 0x0000000400000000: uint(64);
-      v = v | 0x0000002000000000: uint(64);
-      v = v | 0x0000010000000000: uint(64);
-      v = v | 0x0000080000000000: uint(64);
-      v = v | 0x0000400000000000: uint(64);
-      v = v | 0x0002000000000000: uint(64);
-      v = v | 0x0010000000000000: uint(64);
-      v = v | 0x0080000000000000: uint(64);
-      v = v | 0x0400000000000000: uint(64);
-      rp(1) = v | 0x2000000000000000: uint(64);
-      v = rp(2) | 0x0000000000000001: uint(64);
-      v = v | 0x0000000000000008: uint(64);
-      v = v | 0x0000000000000040: uint(64);
-      v = v | 0x0000000000000200: uint(64);
-      v = v | 0x0000000000001000: uint(64);
-      v = v | 0x0000000000008000: uint(64);
-      v = v | 0x0000000000040000: uint(64);
-      v = v | 0x0000000000200000: uint(64);
-      v = v | 0x0000000001000000: uint(64);
-      v = v | 0x0000000008000000: uint(64);
-      v = v | 0x0000000040000000: uint(64);
-      v = v | 0x0000000200000000: uint(64);
-      v = v | 0x0000001000000000: uint(64);
-      v = v | 0x0000008000000000: uint(64);
-      v = v | 0x0000040000000000: uint(64);
-      v = v | 0x0000200000000000: uint(64);
-      v = v | 0x0001000000000000: uint(64);
-      v = v | 0x0008000000000000: uint(64);
-      v = v | 0x0040000000000000: uint(64);
-      v = v | 0x0200000000000000: uint(64);
-      v = v | 0x1000000000000000: uint(64);
-      rp(2) = v | 0x8000000000000000: uint(64);
-      rp += stp;
-    }
-    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
-    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    return biti;
-  }
-}
-
-class URh5: UR {
-  // hybrid bit setting by densely packed uint64's...
-  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
-    const ilmt = si | 63; // make stop limit to next 64-bit boundary
-    var biti = si;
-    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    const rlmtp =
-      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
-    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
-    while rp: int(64) <= rlmtp: int(64) {
-      var v = rp(0) | 0x0000000000000004: uint(64);
-      v = v | 0x0000000000000080: uint(64);
-      v = v | 0x0000000000001000: uint(64);
-      v = v | 0x0000000000020000: uint(64);
-      v = v | 0x0000000000400000: uint(64);
-      v = v | 0x0000000008000000: uint(64);
-      v = v | 0x0000000100000000: uint(64);
-      v = v | 0x0000002000000000: uint(64);
-      v = v | 0x0000040000000000: uint(64);
-      v = v | 0x0000800000000000: uint(64);
-      v = v | 0x0010000000000000: uint(64);
-      v = v | 0x0200000000000000: uint(64);
-      rp(0) = v | 0x4000000000000000: uint(64);
-      v = rp(1) | 0x0000000000000008: uint(64);
-      v = v | 0x0000000000000100: uint(64);
-      v = v | 0x0000000000002000: uint(64);
-      v = v | 0x0000000000040000: uint(64);
-      v = v | 0x0000000000800000: uint(64);
-      v = v | 0x0000000010000000: uint(64);
-      v = v | 0x0000000200000000: uint(64);
-      v = v | 0x0000004000000000: uint(64);
-      v = v | 0x0000080000000000: uint(64);
-      v = v | 0x0001000000000000: uint(64);
-      v = v | 0x0020000000000000: uint(64);
-      v = v | 0x0400000000000000: uint(64);
-      rp(1) = v | 0x8000000000000000: uint(64);
-      v = rp(2) | 0x0000000000000010: uint(64);
-      v = v | 0x0000000000000200: uint(64);
-      v = v | 0x0000000000004000: uint(64);
-      v = v | 0x0000000000080000: uint(64);
-      v = v | 0x0000000001000000: uint(64);
-      v = v | 0x0000000020000000: uint(64);
-      v = v | 0x0000000400000000: uint(64);
-      v = v | 0x0000008000000000: uint(64);
-      v = v | 0x0000100000000000: uint(64);
-      v = v | 0x0002000000000000: uint(64);
-      v = v | 0x0040000000000000: uint(64);
-      rp(2) = v | 0x0800000000000000: uint(64);
-      v = rp(3) | 0x0000000000000001: uint(64);
-      v = v | 0x0000000000000020: uint(64);
-      v = v | 0x0000000000000400: uint(64);
-      v = v | 0x0000000000008000: uint(64);
-      v = v | 0x0000000000100000: uint(64);
-      v = v | 0x0000000002000000: uint(64);
-      v = v | 0x0000000040000000: uint(64);
-      v = v | 0x0000000800000000: uint(64);
-      v = v | 0x0000010000000000: uint(64);
-      v = v | 0x0000200000000000: uint(64);
-      v = v | 0x0004000000000000: uint(64);
-      v = v | 0x0080000000000000: uint(64);
-      rp(3) = v | 0x1000000000000000: uint(64);
-      v = rp(4) | 0x0000000000000002: uint(64);
-      v = v | 0x0000000000000040: uint(64);
-      v = v | 0x0000000000000800: uint(64);
-      v = v | 0x0000000000010000: uint(64);
-      v = v | 0x0000000000200000: uint(64);
-      v = v | 0x0000000004000000: uint(64);
-      v = v | 0x0000000080000000: uint(64);
-      v = v | 0x0000001000000000: uint(64);
-      v = v | 0x0000020000000000: uint(64);
-      v = v | 0x0000400000000000: uint(64);
-      v = v | 0x0008000000000000: uint(64);
-      v = v | 0x0100000000000000: uint(64);
-      rp(4) = v | 0x2000000000000000: uint(64);
-      rp += stp;
-    }
-    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
-    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    return biti;
-  }
-}
-
-class URh7: UR {
-  // hybrid bit setting by densely packed uint64's...
-  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
-    const ilmt = si | 63; // make stop limit to next 64-bit boundary
-    var biti = si;
-    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    const rlmtp =
-      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
-    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
-    while rp: int(64) <= rlmtp: int(64) {
-      var v = rp(0) | 0x0000000000000002: uint(64);
-      v = v | 0x0000000000000100: uint(64);
-      v = v | 0x0000000000008000: uint(64);
-      v = v | 0x0000000000400000: uint(64);
-      v = v | 0x0000000020000000: uint(64);
-      v = v | 0x0000001000000000: uint(64);
-      v = v | 0x0000080000000000: uint(64);
-      v = v | 0x0004000000000000: uint(64);
-      rp(0) = v | 0x0200000000000000: uint(64);
-      v = rp(1) | 0x0000000000000001: uint(64);
-      v = v | 0x0000000000000080: uint(64);
-      v = v | 0x0000000000004000: uint(64);
-      v = v | 0x0000000000200000: uint(64);
-      v = v | 0x0000000010000000: uint(64);
-      v = v | 0x0000000800000000: uint(64);
-      v = v | 0x0000040000000000: uint(64);
-      v = v | 0x0002000000000000: uint(64);
-      v = v | 0x0100000000000000: uint(64);
-      rp(1) = v | 0x8000000000000000: uint(64);
-      v = rp(2) | 0x0000000000000040: uint(64);
-      v = v | 0x0000000000002000: uint(64);
-      v = v | 0x0000000000100000: uint(64);
-      v = v | 0x0000000008000000: uint(64);
-      v = v | 0x0000000400000000: uint(64);
-      v = v | 0x0000020000000000: uint(64);
-      v = v | 0x0001000000000000: uint(64);
-      v = v | 0x0080000000000000: uint(64);
-      rp(2) = v | 0x4000000000000000: uint(64);
-      v = rp(3) | 0x0000000000000020: uint(64);
-      v = v | 0x0000000000001000: uint(64);
-      v = v | 0x0000000000080000: uint(64);
-      v = v | 0x0000000004000000: uint(64);
-      v = v | 0x0000000200000000: uint(64);
-      v = v | 0x0000010000000000: uint(64);
-      v = v | 0x0000800000000000: uint(64);
-      v = v | 0x0040000000000000: uint(64);
-      rp(3) = v | 0x2000000000000000: uint(64);
-      v = rp(4) | 0x0000000000000010: uint(64);
-      v = v | 0x0000000000000800: uint(64);
-      v = v | 0x0000000000040000: uint(64);
-      v = v | 0x0000000002000000: uint(64);
-      v = v | 0x0000000100000000: uint(64);
-      v = v | 0x0000008000000000: uint(64);
-      v = v | 0x0000400000000000: uint(64);
-      v = v | 0x0020000000000000: uint(64);
-      rp(4) = v | 0x1000000000000000: uint(64);
-      v = rp(5) | 0x0000000000000008: uint(64);
-      v = v | 0x0000000000000400: uint(64);
-      v = v | 0x0000000000020000: uint(64);
-      v = v | 0x0000000001000000: uint(64);
-      v = v | 0x0000000080000000: uint(64);
-      v = v | 0x0000004000000000: uint(64);
-      v = v | 0x0000200000000000: uint(64);
-      v = v | 0x0010000000000000: uint(64);
-      rp(5) = v | 0x0800000000000000: uint(64);
-      v = rp(6) | 0x0000000000000004: uint(64);
-      v = v | 0x0000000000000200: uint(64);
-      v = v | 0x0000000000010000: uint(64);
-      v = v | 0x0000000000800000: uint(64);
-      v = v | 0x0000000040000000: uint(64);
-      v = v | 0x0000002000000000: uint(64);
-      v = v | 0x0000100000000000: uint(64);
-      v = v | 0x0008000000000000: uint(64);
-      rp(6) = v | 0x0400000000000000: uint(64);
-      rp += stp;
-    }
-    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
-    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    return biti;
-  }
-}
-
-class URh9: UR {
-  // hybrid bit setting by densely packed uint64's...
-  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
-    const ilmt = si | 63; // make stop limit to next 64-bit boundary
-    var biti = si;
-    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    const rlmtp =
-      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
-    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
-    while rp: int(64) <= rlmtp: int(64) {
-      var v = rp(0) | 0x0000000000000004: uint(64);
-      v = v | 0x0000000000000800: uint(64);
-      v = v | 0x0000000000100000: uint(64);
-      v = v | 0x0000000020000000: uint(64);
-      v = v | 0x0000004000000000: uint(64);
-      v = v | 0x0000800000000000: uint(64);
-      rp(0) = v | 0x0100000000000000: uint(64);
-      v = rp(1) | 0x0000000000000002: uint(64);
-      v = v | 0x0000000000000400: uint(64);
-      v = v | 0x0000000000080000: uint(64);
-      v = v | 0x0000000010000000: uint(64);
-      v = v | 0x0000002000000000: uint(64);
-      v = v | 0x0000400000000000: uint(64);
-      rp(1) = v | 0x0080000000000000: uint(64);
-      v = rp(2) | 0x0000000000000001: uint(64);
-      v = v | 0x0000000000000200: uint(64);
-      v = v | 0x0000000000040000: uint(64);
-      v = v | 0x0000000008000000: uint(64);
-      v = v | 0x0000001000000000: uint(64);
-      v = v | 0x0000200000000000: uint(64);
-      v = v | 0x0040000000000000: uint(64);
-      rp(2) = v | 0x8000000000000000: uint(64);
-      v = rp(3) | 0x0000000000000100: uint(64);
-      v = v | 0x0000000000020000: uint(64);
-      v = v | 0x0000000004000000: uint(64);
-      v = v | 0x0000000800000000: uint(64);
-      v = v | 0x0000100000000000: uint(64);
-      v = v | 0x0020000000000000: uint(64);
-      rp(3) = v | 0x4000000000000000: uint(64);
-      v = rp(4) | 0x0000000000000080: uint(64);
-      v = v | 0x0000000000010000: uint(64);
-      v = v | 0x0000000002000000: uint(64);
-      v = v | 0x0000000400000000: uint(64);
-      v = v | 0x0000080000000000: uint(64);
-      v = v | 0x0010000000000000: uint(64);
-      rp(4) = v | 0x2000000000000000: uint(64);
-      v = rp(5) | 0x0000000000000040: uint(64);
-      v = v | 0x0000000000008000: uint(64);
-      v = v | 0x0000000001000000: uint(64);
-      v = v | 0x0000000200000000: uint(64);
-      v = v | 0x0000040000000000: uint(64);
-      v = v | 0x0008000000000000: uint(64);
-      rp(5) = v | 0x1000000000000000: uint(64);
-      v = rp(6) | 0x0000000000000020: uint(64);
-      v = v | 0x0000000000004000: uint(64);
-      v = v | 0x0000000000800000: uint(64);
-      v = v | 0x0000000100000000: uint(64);
-      v = v | 0x0000020000000000: uint(64);
-      v = v | 0x0004000000000000: uint(64);
-      rp(6) = v | 0x0800000000000000: uint(64);
-      v = rp(7) | 0x0000000000000010: uint(64);
-      v = v | 0x0000000000002000: uint(64);
-      v = v | 0x0000000000400000: uint(64);
-      v = v | 0x0000000080000000: uint(64);
-      v = v | 0x0000010000000000: uint(64);
-      v = v | 0x0002000000000000: uint(64);
-      rp(7) = v | 0x0400000000000000: uint(64);
-      v = rp(8) | 0x0000000000000008: uint(64);
-      v = v | 0x0000000000001000: uint(64);
-      v = v | 0x0000000000200000: uint(64);
-      v = v | 0x0000000040000000: uint(64);
-      v = v | 0x0000008000000000: uint(64);
-      v = v | 0x0001000000000000: uint(64);
-      rp(8) = v | 0x0200000000000000: uint(64);
-      rp += stp;
-    }
-    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
-    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    return biti;
-  }
-}
-
-class URh11: UR {
-  // hybrid bit setting by densely packed uint64's...
-  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
-    const ilmt = si | 63; // make stop limit to next 64-bit boundary
-    var biti = si;
-    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    const rlmtp =
-      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
-    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
-    while rp: int(64) <= rlmtp: int(64) {
-      var v = rp(0) | 0x0000000000000040: uint(64);
-      v = v | 0x0000000000020000: uint(64);
-      v = v | 0x0000000010000000: uint(64);
-      v = v | 0x0000008000000000: uint(64);
-      v = v | 0x0004000000000000: uint(64);
-      rp(0) = v | 0x2000000000000000: uint(64);
-      v = rp(1) | 0x0000000000000100: uint(64);
-      v = v | 0x0000000000080000: uint(64);
-      v = v | 0x0000000040000000: uint(64);
-      v = v | 0x0000020000000000: uint(64);
-      v = v | 0x0010000000000000: uint(64);
-      rp(1) = v | 0x8000000000000000: uint(64);
-      v = rp(2) | 0x0000000000000400: uint(64);
-      v = v | 0x0000000000200000: uint(64);
-      v = v | 0x0000000100000000: uint(64);
-      v = v | 0x0000080000000000: uint(64);
-      rp(2) = v | 0x0040000000000000: uint(64);
-      v = rp(3) | 0x0000000000000002: uint(64);
-      v = v | 0x0000000000001000: uint(64);
-      v = v | 0x0000000000800000: uint(64);
-      v = v | 0x0000000400000000: uint(64);
-      v = v | 0x0000200000000000: uint(64);
-      rp(3) = v | 0x0100000000000000: uint(64);
-      v = rp(4) | 0x0000000000000008: uint(64);
-      v = v | 0x0000000000004000: uint(64);
-      v = v | 0x0000000002000000: uint(64);
-      v = v | 0x0000001000000000: uint(64);
-      v = v | 0x0000800000000000: uint(64);
-      rp(4) = v | 0x0400000000000000: uint(64);
-      v = rp(5) | 0x0000000000000020: uint(64);
-      v = v | 0x0000000000010000: uint(64);
-      v = v | 0x0000000008000000: uint(64);
-      v = v | 0x0000004000000000: uint(64);
-      v = v | 0x0002000000000000: uint(64);
-      rp(5) = v | 0x1000000000000000: uint(64);
-      v = rp(6) | 0x0000000000000080: uint(64);
-      v = v | 0x0000000000040000: uint(64);
-      v = v | 0x0000000020000000: uint(64);
-      v = v | 0x0000010000000000: uint(64);
-      v = v | 0x0008000000000000: uint(64);
-      rp(6) = v | 0x4000000000000000: uint(64);
-      v = rp(7) | 0x0000000000000200: uint(64);
-      v = v | 0x0000000000100000: uint(64);
-      v = v | 0x0000000080000000: uint(64);
-      v = v | 0x0000040000000000: uint(64);
-      rp(7) = v | 0x0020000000000000: uint(64);
-      v = rp(8) | 0x0000000000000001: uint(64);
-      v = v | 0x0000000000000800: uint(64);
-      v = v | 0x0000000000400000: uint(64);
-      v = v | 0x0000000200000000: uint(64);
-      v = v | 0x0000100000000000: uint(64);
-      rp(8) = v | 0x0080000000000000: uint(64);
-      v = rp(9) | 0x0000000000000004: uint(64);
-      v = v | 0x0000000000002000: uint(64);
-      v = v | 0x0000000001000000: uint(64);
-      v = v | 0x0000000800000000: uint(64);
-      v = v | 0x0000400000000000: uint(64);
-      rp(9) = v | 0x0200000000000000: uint(64);
-      v = rp(10) | 0x0000000000000010: uint(64);
-      v = v | 0x0000000000008000: uint(64);
-      v = v | 0x0000000004000000: uint(64);
-      v = v | 0x0000002000000000: uint(64);
-      v = v | 0x0001000000000000: uint(64);
-      rp(10) = v | 0x0800000000000000: uint(64);
-      rp += stp;
-    }
-    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
-    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    return biti;
-  }
-}
-
-class URh13: UR {
-  // hybrid bit setting by densely packed uint64's...
-  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
-    const ilmt = si | 63; // make stop limit to next 64-bit boundary
-    var biti = si;
-    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    const rlmtp =
-      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
-    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
-    while rp: int(64) <= rlmtp: int(64) {
-      var v = rp(0) | 0x0000000000000080: uint(64);
-      v = v | 0x0000000000100000: uint(64);
-      v = v | 0x0000000200000000: uint(64);
-      v = v | 0x0000400000000000: uint(64);
-      rp(0) = v | 0x0800000000000000: uint(64);
-      v = rp(1) | 0x0000000000000100: uint(64);
-      v = v | 0x0000000000200000: uint(64);
-      v = v | 0x0000000400000000: uint(64);
-      v = v | 0x0000800000000000: uint(64);
-      rp(1) = v | 0x1000000000000000: uint(64);
-      v = rp(2) | 0x0000000000000200: uint(64);
-      v = v | 0x0000000000400000: uint(64);
-      v = v | 0x0000000800000000: uint(64);
-      v = v | 0x0001000000000000: uint(64);
-      rp(2) = v | 0x2000000000000000: uint(64);
-      v = rp(3) | 0x0000000000000400: uint(64);
-      v = v | 0x0000000000800000: uint(64);
-      v = v | 0x0000001000000000: uint(64);
-      v = v | 0x0002000000000000: uint(64);
-      rp(3) = v | 0x4000000000000000: uint(64);
-      v = rp(4) | 0x0000000000000800: uint(64);
-      v = v | 0x0000000001000000: uint(64);
-      v = v | 0x0000002000000000: uint(64);
-      v = v | 0x0004000000000000: uint(64);
-      rp(4) = v | 0x8000000000000000: uint(64);
-      v = rp(5) | 0x0000000000001000: uint(64);
-      v = v | 0x0000000002000000: uint(64);
-      v = v | 0x0000004000000000: uint(64);
-      rp(5) = v | 0x0008000000000000: uint(64);
-      v = rp(6) | 0x0000000000000001: uint(64);
-      v = v | 0x0000000000002000: uint(64);
-      v = v | 0x0000000004000000: uint(64);
-      v = v | 0x0000008000000000: uint(64);
-      rp(6) = v | 0x0010000000000000: uint(64);
-      v = rp(7) | 0x0000000000000002: uint(64);
-      v = v | 0x0000000000004000: uint(64);
-      v = v | 0x0000000008000000: uint(64);
-      v = v | 0x0000010000000000: uint(64);
-      rp(7) = v | 0x0020000000000000: uint(64);
-      v = rp(8) | 0x0000000000000004: uint(64);
-      v = v | 0x0000000000008000: uint(64);
-      v = v | 0x0000000010000000: uint(64);
-      v = v | 0x0000020000000000: uint(64);
-      rp(8) = v | 0x0040000000000000: uint(64);
-      v = rp(9) | 0x0000000000000008: uint(64);
-      v = v | 0x0000000000010000: uint(64);
-      v = v | 0x0000000020000000: uint(64);
-      v = v | 0x0000040000000000: uint(64);
-      rp(9) = v | 0x0080000000000000: uint(64);
-      v = rp(10) | 0x0000000000000010: uint(64);
-      v = v | 0x0000000000020000: uint(64);
-      v = v | 0x0000000040000000: uint(64);
-      v = v | 0x0000080000000000: uint(64);
-      rp(10) = v | 0x0100000000000000: uint(64);
-      v = rp(11) | 0x0000000000000020: uint(64);
-      v = v | 0x0000000000040000: uint(64);
-      v = v | 0x0000000080000000: uint(64);
-      v = v | 0x0000100000000000: uint(64);
-      rp(11) = v | 0x0200000000000000: uint(64);
-      v = rp(12) | 0x0000000000000040: uint(64);
-      v = v | 0x0000000000080000: uint(64);
-      v = v | 0x0000000100000000: uint(64);
-      v = v | 0x0000200000000000: uint(64);
-      rp(12) = v | 0x0400000000000000: uint(64);
-      rp += stp;
-    }
-    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
-    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    return biti;
-  }
-}
-
-class URh15: UR {
-  // hybrid bit setting by densely packed uint64's...
-  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
-    const ilmt = si | 63; // make stop limit to next 64-bit boundary
-    var biti = si;
-    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    const rlmtp =
-      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
-    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
-    while rp: int(64) <= rlmtp: int(64) {
-      var v = rp(0) | 0x0000000000002000: uint(64);
-      v = v | 0x0000000010000000: uint(64);
-      v = v | 0x0000080000000000: uint(64);
-      rp(0) = v | 0x0400000000000000: uint(64);
-      v = rp(1) | 0x0000000000000200: uint(64);
-      v = v | 0x0000000001000000: uint(64);
-      v = v | 0x0000008000000000: uint(64);
-      rp(1) = v | 0x0040000000000000: uint(64);
-      v = rp(2) | 0x0000000000000020: uint(64);
-      v = v | 0x0000000000100000: uint(64);
-      v = v | 0x0000000800000000: uint(64);
-      rp(2) = v | 0x0004000000000000: uint(64);
-      v = rp(3) | 0x0000000000000002: uint(64);
-      v = v | 0x0000000000010000: uint(64);
-      v = v | 0x0000000080000000: uint(64);
-      v = v | 0x0000400000000000: uint(64);
-      rp(3) = v | 0x2000000000000000: uint(64);
-      v = rp(4) | 0x0000000000001000: uint(64);
-      v = v | 0x0000000008000000: uint(64);
-      v = v | 0x0000040000000000: uint(64);
-      rp(4) = v | 0x0200000000000000: uint(64);
-      v = rp(5) | 0x0000000000000100: uint(64);
-      v = v | 0x0000000000800000: uint(64);
-      v = v | 0x0000004000000000: uint(64);
-      rp(5) = v | 0x0020000000000000: uint(64);
-      v = rp(6) | 0x0000000000000010: uint(64);
-      v = v | 0x0000000000080000: uint(64);
-      v = v | 0x0000000400000000: uint(64);
-      rp(6) = v | 0x0002000000000000: uint(64);
-      v = rp(7) | 0x0000000000000001: uint(64);
-      v = v | 0x0000000000008000: uint(64);
-      v = v | 0x0000000040000000: uint(64);
-      v = v | 0x0000200000000000: uint(64);
-      rp(7) = v | 0x1000000000000000: uint(64);
-      v = rp(8) | 0x0000000000000800: uint(64);
-      v = v | 0x0000000004000000: uint(64);
-      v = v | 0x0000020000000000: uint(64);
-      rp(8) = v | 0x0100000000000000: uint(64);
-      v = rp(9) | 0x0000000000000080: uint(64);
-      v = v | 0x0000000000400000: uint(64);
-      v = v | 0x0000002000000000: uint(64);
-      rp(9) = v | 0x0010000000000000: uint(64);
-      v = rp(10) | 0x0000000000000008: uint(64);
-      v = v | 0x0000000000040000: uint(64);
-      v = v | 0x0000000200000000: uint(64);
-      v = v | 0x0001000000000000: uint(64);
-      rp(10) = v | 0x8000000000000000: uint(64);
-      v = rp(11) | 0x0000000000004000: uint(64);
-      v = v | 0x0000000020000000: uint(64);
-      v = v | 0x0000100000000000: uint(64);
-      rp(11) = v | 0x0800000000000000: uint(64);
-      v = rp(12) | 0x0000000000000400: uint(64);
-      v = v | 0x0000000002000000: uint(64);
-      v = v | 0x0000010000000000: uint(64);
-      rp(12) = v | 0x0080000000000000: uint(64);
-      v = rp(13) | 0x0000000000000040: uint(64);
-      v = v | 0x0000000000200000: uint(64);
-      v = v | 0x0000001000000000: uint(64);
-      rp(13) = v | 0x0008000000000000: uint(64);
-      v = rp(14) | 0x0000000000000004: uint(64);
-      v = v | 0x0000000000020000: uint(64);
-      v = v | 0x0000000100000000: uint(64);
-      v = v | 0x0000800000000000: uint(64);
-      rp(14) = v | 0x4000000000000000: uint(64);
-      rp += stp;
-    }
-    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
-    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    return biti;
-  }
-}
-
-class URh17: UR {
-  // hybrid bit setting by densely packed uint64's...
-  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
-    const ilmt = si | 63; // make stop limit to next 64-bit boundary
-    var biti = si;
-    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    const rlmtp =
-      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
-    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
-    while rp: int(64) <= rlmtp: int(64) {
-     var v = rp(0) | 0x0000000000000004: uint(64);
-      v = v | 0x0000000000080000: uint(64);
-      v = v | 0x0000001000000000: uint(64);
-      rp(0) = v | 0x0020000000000000: uint(64);
-      v = rp(1) | 0x0000000000000040: uint(64);
-      v = v | 0x0000000000800000: uint(64);
-      v = v | 0x0000010000000000: uint(64);
-      rp(1) = v | 0x0200000000000000: uint(64);
-      v = rp(2) | 0x0000000000000400: uint(64);
-      v = v | 0x0000000008000000: uint(64);
-      v = v | 0x0000100000000000: uint(64);
-      rp(2) = v | 0x2000000000000000: uint(64);
-      v = rp(3) | 0x0000000000004000: uint(64);
-      v = v | 0x0000000080000000: uint(64);
-      rp(3) = v | 0x0001000000000000: uint(64);
-      v = rp(4) | 0x0000000000000002: uint(64);
-      v = v | 0x0000000000040000: uint(64);
-      v = v | 0x0000000800000000: uint(64);
-      rp(4) = v | 0x0010000000000000: uint(64);
-      v = rp(5) | 0x0000000000000020: uint(64);
-      v = v | 0x0000000000400000: uint(64);
-      v = v | 0x0000008000000000: uint(64);
-      rp(5) = v | 0x0100000000000000: uint(64);
-      v = rp(6) | 0x0000000000000200: uint(64);
-      v = v | 0x0000000004000000: uint(64);
-      v = v | 0x0000080000000000: uint(64);
-      rp(6) = v | 0x1000000000000000: uint(64);
-      v = rp(7) | 0x0000000000002000: uint(64);
-      v = v | 0x0000000040000000: uint(64);
-      rp(7) = v | 0x0000800000000000: uint(64);
-      v = rp(8) | 0x0000000000000001: uint(64);
-      v = v | 0x0000000000020000: uint(64);
-      v = v | 0x0000000400000000: uint(64);
-      rp(8) = v | 0x0008000000000000: uint(64);
-      v = rp(9) | 0x0000000000000010: uint(64);
-      v = v | 0x0000000000200000: uint(64);
-      v = v | 0x0000004000000000: uint(64);
-      rp(9) = v | 0x0080000000000000: uint(64);
-      v = rp(10) | 0x0000000000000100: uint(64);
-      v = v | 0x0000000002000000: uint(64);
-      v = v | 0x0000040000000000: uint(64);
-      rp(10) = v | 0x0800000000000000: uint(64);
-      v = rp(11) | 0x0000000000001000: uint(64);
-      v = v | 0x0000000020000000: uint(64);
-      v = v | 0x0000400000000000: uint(64);
-      rp(11) = v | 0x8000000000000000: uint(64);
-      v = rp(12) | 0x0000000000010000: uint(64);
-      v = v | 0x0000000200000000: uint(64);
-      rp(12) = v | 0x0004000000000000: uint(64);
-      v = rp(13) | 0x0000000000000008: uint(64);
-      v = v | 0x0000000000100000: uint(64);
-      v = v | 0x0000002000000000: uint(64);
-      rp(13) = v | 0x0040000000000000: uint(64);
-      v = rp(14) | 0x0000000000000080: uint(64);
-      v = v | 0x0000000001000000: uint(64);
-      v = v | 0x0000020000000000: uint(64);
-      rp(14) = v | 0x0400000000000000: uint(64);
-      v = rp(15) | 0x0000000000000800: uint(64);
-      v = v | 0x0000000010000000: uint(64);
-      v = v | 0x0000200000000000: uint(64);
-      rp(15) = v | 0x4000000000000000: uint(64);
-      v = rp(16) | 0x0000000000008000: uint(64);
-      v = v | 0x0000000100000000: uint(64);
-      rp(16) = v | 0x0002000000000000: uint(64);
-      rp += stp;
-    }
-    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
-    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    return biti;
-  }
-}
-
-class URh19: UR {
-  // hybrid bit setting by densely packed uint64's...
-  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
-    const ilmt = si | 63; // make stop limit to next 64-bit boundary
-    var biti = si;
-    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
-    const rlmtp =
-      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
-    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
-    while rp: int(64) <= rlmtp: int(64) {
-      var v = rp(0) | 0x0000000000000040: uint(64);
-      v = v | 0x0000000002000000: uint(64);
-      v = v | 0x0000100000000000: uint(64);
-      rp(0) = v | 0x8000000000000000: uint(64);
-      v = rp(1) | 0x0000000000040000: uint(64);
-      v = v | 0x0000002000000000: uint(64);
-      rp(1) = v | 0x0100000000000000: uint(64);
-      v = rp(2) | 0x0000000000000800: uint(64);
-      v = v | 0x0000000040000000: uint(64);
-      rp(2) = v | 0x0002000000000000: uint(64);
-      v = rp(3) | 0x0000000000000010: uint(64);
-      v = v | 0x0000000000800000: uint(64);
-      v = v | 0x0000040000000000: uint(64);
-      rp(3) = v | 0x2000000000000000: uint(64);
-      v = rp(4) | 0x0000000000010000: uint(64);
-      v = v | 0x0000000800000000: uint(64);
-      rp(4) = v | 0x0040000000000000: uint(64);
-      v = rp(5) | 0x0000000000000200: uint(64);
-      v = v | 0x0000000010000000: uint(64);
-      rp(5) = v | 0x0000800000000000: uint(64);
-      v = rp(6) | 0x0000000000000004: uint(64);
-      v = v | 0x0000000000200000: uint(64);
-      v = v | 0x0000010000000000: uint(64);
-      rp(6) = v | 0x0800000000000000: uint(64);
-      v = rp(7) | 0x0000000000004000: uint(64);
-      v = v | 0x0000000200000000: uint(64);
-      rp(7) = v | 0x0010000000000000: uint(64);
-      v = rp(8) | 0x0000000000000080: uint(64);
-      v = v | 0x0000000004000000: uint(64);
-      rp(8) = v | 0x0000200000000000: uint(64);
-      v = rp(9) | 0x0000000000000001: uint(64);
-      v = v | 0x0000000000080000: uint(64);
-      v = v | 0x0000004000000000: uint(64);
-      rp(9) = v | 0x0200000000000000: uint(64);
-      v = rp(10) | 0x0000000000001000: uint(64);
-      v = v | 0x0000000080000000: uint(64);
-      rp(10) = v | 0x0004000000000000: uint(64);
-      v = rp(11) | 0x0000000000000020: uint(64);
-      v = v | 0x0000000001000000: uint(64);
-      v = v | 0x0000080000000000: uint(64);
-      rp(11) = v | 0x4000000000000000: uint(64);
-      v = rp(12) | 0x0000000000020000: uint(64);
-      v = v | 0x0000001000000000: uint(64);
-      rp(12) = v | 0x0080000000000000: uint(64);
-      v = rp(13) | 0x0000000000000400: uint(64);
-      v = v | 0x0000000020000000: uint(64);
-      rp(13) = v | 0x0001000000000000: uint(64);
-      v = rp(14) | 0x0000000000000008: uint(64);
-      v = v | 0x0000000000400000: uint(64);
-      v = v | 0x0000020000000000: uint(64);
-      rp(14) = v | 0x1000000000000000: uint(64);
-      v = rp(15) | 0x0000000000008000: uint(64);
-      v = v | 0x0000000400000000: uint(64);
-      rp(15) = v | 0x0020000000000000: uint(64);
-      v = rp(16) | 0x0000000000000100: uint(64);
-      v = v | 0x0000000008000000: uint(64);
-      rp(16) = v | 0x0000400000000000: uint(64);
-      v = rp(17) | 0x0000000000000002: uint(64);
-      v = v | 0x0000000000100000: uint(64);
-      v = v | 0x0000008000000000: uint(64);
-      rp(17) = v | 0x0400000000000000: uint(64);
-      v = rp(18) | 0x0000000000002000: uint(64);
-      v = v | 0x0000000100000000: uint(64);
-      rp(18) = v | 0x0008000000000000: uint(64);
+      var v = rp(0) | m0: uint(64); rp(0) = v; v = rp(i1);
+      v |= m1: uint(64); rp(i1) = v; v = rp(i2);
+      v |= m2: uint(64); rp(i2) = v; v = rp(i3);
+      v |= m3: uint(64); rp(i3) = v; v = rp(i4);
+      v |= m4: uint(64); rp(i4) = v; v = rp(i5);
+      v |= m5: uint(64); rp(i5) = v; v = rp(i6);
+      v |= m6: uint(64); rp(i6) = v; v = rp(i7);
+      v |= m7: uint(64); rp(i7) = v; v = rp(i8);
+      v |= m8: uint(64); rp(i8) = v; v = rp(i9);
+      v |= m9: uint(64); rp(i9) = v; v = rp(i10);
+      v |= m10: uint(64); rp(i10) = v; v = rp(i11);
+      v |= m11: uint(64); rp(i11) = v; v = rp(i12);
+      v |= m12: uint(64); rp(i12) = v; v = rp(i13);
+      v |= m13: uint(64); rp(i13) = v; v = rp(i14);
+      v |= m14: uint(64); rp(i14) = v; v = rp(i15);
+      v |= m15: uint(64); rp(i15) = v; v = rp(i16);
+      v |= m16: uint(64); rp(i16) = v; v = rp(i17);
+      v |= m17: uint(64); rp(i17) = v; v = rp(i18);
+      v |= m18: uint(64); rp(i18) = v; v = rp(i19);
+      v |= m19: uint(64); rp(i19) = v; v = rp(i20);
+      v |= m20: uint(64); rp(i20) = v; v = rp(i21);
+      v |= m21: uint(64); rp(i21) = v; v = rp(i22);
+      v |= m22: uint(64); rp(i22) = v; v = rp(i23);
+      v |= m23: uint(64); rp(i23) = v; v = rp(i24);
+      v |= m24: uint(64); rp(i24) = v; v = rp(i25);
+      v |= m25: uint(64); rp(i25) = v; v = rp(i26);
+      v |= m26: uint(64); rp(i26) = v; v = rp(i27);
+      v |= m27: uint(64); rp(i27) = v; v = rp(i28);
+      v |= m28: uint(64); rp(i28) = v; v = rp(i29);
+      v |= m29: uint(64); rp(i29) = v; v = rp(i30);
+      v |= m30: uint(64); rp(i30) = v; v = rp(i31);
+      v |= m31: uint(64); rp(i31) = v; v = rp(i32);
+      v |= m32: uint(64); rp(i32) = v; v = rp(i33);
+      v |= m33: uint(64); rp(i33) = v; v = rp(i34);
+      v |= m34: uint(64); rp(i34) = v; v = rp(i35);
+      v |= m35: uint(64); rp(i35) = v; v = rp(i36);
+      v |= m36: uint(64); rp(i36) = v; v = rp(i37);
+      v |= m37: uint(64); rp(i37) = v; v = rp(i38);
+      v |= m38: uint(64); rp(i38) = v; v = rp(i39);
+      v |= m39: uint(64); rp(i39) = v; v = rp(i40);
+      v |= m40: uint(64); rp(i40) = v; v = rp(i41);
+      v |= m41: uint(64); rp(i41) = v; v = rp(i42);
+      v |= m42: uint(64); rp(i42) = v; v = rp(i43);
+      v |= m43: uint(64); rp(i43) = v; v = rp(i44);
+      v |= m44: uint(64); rp(i44) = v; v = rp(i45);
+      v |= m45: uint(64); rp(i45) = v; v = rp(i46);
+      v |= m46: uint(64); rp(i46) = v; v = rp(i47);
+      v |= m47: uint(64); rp(i47) = v; v = rp(i48);
+      v |= m48: uint(64); rp(i48) = v; v = rp(i49);
+      v |= m49: uint(64); rp(i49) = v; v = rp(i50);
+      v |= m50: uint(64); rp(i50) = v; v = rp(i51);
+      v |= m51: uint(64); rp(i51) = v; v = rp(i52);
+      v |= m52: uint(64); rp(i52) = v; v = rp(i53);
+      v |= m53: uint(64); rp(i53) = v; v = rp(i54);
+      v |= m54: uint(64); rp(i54) = v; v = rp(i55);
+      v |= m55: uint(64); rp(i55) = v; v = rp(i56);
+      v |= m56: uint(64); rp(i56) = v; v = rp(i57);
+      v |= m57: uint(64); rp(i57) = v; v = rp(i58);
+      v |= m58: uint(64); rp(i58) = v; v = rp(i59);
+      v |= m59: uint(64); rp(i59) = v; v = rp(i60);
+      v |= m60: uint(64); rp(i60) = v; v = rp(i61);
+      v |= m61: uint(64); rp(i61) = v; v = rp(i62);
+      v |= m62: uint(64); rp(i62) = v; v = rp(i63);
+      rp(i63) = v | m63: uint(64);
       rp += stp;
     }
     biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
@@ -849,13 +264,15 @@ class URh19: UR {
 }
 
 // a computed goto jump table using modulo pattern closure classes...
-const hybrid = [ // note only cases 3, 5, 7 .. 19 are used; 9 and 15 never hit!
-  new URr(0): OUR, new URr(1): OUR, new URr(2): OUR, new URh3(): OUR,
-  new URr(4): OUR, new URh5(): OUR, new URr(6): OUR, new URh7(): OUR,
-  new URr(8): OUR, new URh9(): OUR, new URr(10): OUR, new URh11(): OUR,
-  new URr(12): OUR, new URh13(): OUR, new URr(14): OUR, new URh15(): OUR,
-  new URr(16): OUR, new URh17(): OUR, new URr(18): OUR, new URh19(): OUR,
-  new URr(20): OUR, new URr(21): OUR, new URr(22): OUR, new URr(23): OUR ];
+const hybrid = [
+  new URx(0): OUR, new URx(1): OUR, new URx(2): OUR, new URx(3): OUR,
+  new URx(4): OUR, new URx(5): OUR, new URx(6): OUR, new URx(7): OUR,
+  new URx(8): OUR, new URx(9): OUR, new URx(10): OUR, new URx(11): OUR,
+  new URx(12): OUR, new URx(13): OUR, new URx(14): OUR, new URx(15): OUR,
+  new URx(16): OUR, new URx(17): OUR, new URx(18): OUR, new URx(19): OUR,
+  new URx(20): OUR, new URx(21): OUR, new URx(22): OUR, new URx(23): OUR,
+  new URx(24): OUR, new URx(25): OUR, new URx(26): OUR, new URx(27): OUR,
+  new URx(28): OUR, new URx(29): OUR, new URx(30): OUR, new URx(31): OUR ];
 
 class PrimeSieve {
   const limit: Prime;
@@ -939,7 +356,8 @@ class PrimeSieve {
             var startndx = (i + i) * (i + 3) + 3;
             if startndx > bitlmt then break;
             const bp = i + i + 3;
-            if bp <= 19 then hybrid[bp](bufferp, startndx, bitlmt, bp);
+            if bp <= HYBRID_THRESHOLD then
+              hybrid[i](bufferp, startndx, bitlmt, bp);
             else unrollr[((bp & 7) << 3) | (startndx & 7)]
                    (bufferp, startndx, bitlmt, bp);
           }
@@ -977,14 +395,13 @@ proc benchmark(tech: Techniques) {
     const lbl: string =
       "GordonBGood_" +
         if tech == Techniques.BitTwiddle then "bittwiddle;"
-        else if tech == Techniques.Unpeeled then "unpeeled;"
-        else if tech == Techniques.UnpeeledBlock then "unpeeled_block;"
-        else if tech == Techniques.Unrolled then "unrolled;"
-        else "unrolled_hybrid;";
+        else if tech == Techniques.Unpeeled then "stride8;"
+        else if tech == Techniques.UnpeeledBlock then "stride8_block16K;"
+        else if tech == Techniques.Unrolled then "extreme;"
+        else "extreme_hybrid;";
     writeln(lbl, passes, ";", duration, ";1;algorithm=base,faithful=yes,bits=1");
   }
-  else { writeln("Invalid result!"); }  
+  else { writeln("Invalid result:  ", count, " should be ", EXPECTED, "!"); }  
 }
 
 for t in Techniques do benchmark(t);
-


### PR DESCRIPTION
## Description

For the Extreme Hybrid dense culling technique, use compile time constants instead of code generation to extend the range of the dense base prime threshold while actually shortening the code...

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
